### PR TITLE
Standardised banner location

### DIFF
--- a/app/assets/javascripts/housekeeping.js
+++ b/app/assets/javascripts/housekeeping.js
@@ -433,11 +433,7 @@ $(document).ready(function() {
                     '<div class="govuk-notification-banner__header"><h2 class="govuk-notification-banner__title">Success</h2></div>' +
                     '<div class="govuk-notification-banner__content"><h3 class="govuk-notification-banner__heading">' + message + '</h3></div></div>');
 
-                if (sourceTab === "4") {
-                    $('#tab_content_4 #notification-area').prepend(banner);
-                } else {
-                    $('#tab_content_2 #notification-area').prepend(banner);
-                }
+                $('#notification-area').prepend(banner);
 
                 // Auto-remove banner after 10 seconds
                 setTimeout(function() {
@@ -2145,11 +2141,7 @@ function showStatusUpdateSuccess(type, count, items) {
      '</div>');
 
     // Insert notifications at the top of the content area
-    if (type === 'materials') {
-        $('#materials_column_2 #notification-area').html(notification.show());
-    } else if (type === 'communications') {
-        $('#comms_column_2 #notification-area').html(notification.show());
-    }
+    $('#notification-area').html(notification.show());
 
     // Auto-hide and then REMOVE from DOM
     setTimeout(function() {

--- a/app/views/includes/version-1/tab-2-Materials.html
+++ b/app/views/includes/version-1/tab-2-Materials.html
@@ -13,9 +13,7 @@
     </div>
 
     <div class="govuk-grid-column-three-quarters" id="materials_column_2">
-        <div id="notification-area" class="govuk-grid-row"></div>
         <div class="govuk-grid-row">
-
             <div class="govuk-grid-column-one-half">
                 <div class="info_wrapper">
                     <button id="show_filter_Materials" type="button" class="govuk-button govuk-button--secondary"

--- a/app/views/includes/version-1/tab-4-Comms.html
+++ b/app/views/includes/version-1/tab-4-Comms.html
@@ -13,7 +13,6 @@
     </div>
 
     <div class="govuk-grid-column-three-quarters" id="comms_column_2">
-        <div id="notification-area" class="govuk-grid-row"></div>
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-half">
                 <div class="info_wrapper">

--- a/app/views/version-1/A-index.html
+++ b/app/views/version-1/A-index.html
@@ -53,6 +53,9 @@
             </div>
         </div>
 
+        <!-- RECLASSIFY -->
+        <div id="notification-area" class="govuk-grid-row"></div>
+
         <!-- DISCARD -->
         {% if data['discarding_material_COMPLETED'] == 'true' %}
         <div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-4" role="alert"

--- a/public/javascripts/housekeeping.js
+++ b/public/javascripts/housekeeping.js
@@ -433,11 +433,7 @@ $(document).ready(function() {
                     '<div class="govuk-notification-banner__header"><h2 class="govuk-notification-banner__title">Success</h2></div>' +
                     '<div class="govuk-notification-banner__content"><h3 class="govuk-notification-banner__heading">' + message + '</h3></div></div>');
 
-                if (sourceTab === "4") {
-                    $('#tab_content_4 #notification-area').prepend(banner);
-                } else {
-                    $('#tab_content_2 #notification-area').prepend(banner);
-                }
+                $('#notification-area').prepend(banner);
 
                 // Auto-remove banner after 10 seconds
                 setTimeout(function() {
@@ -2145,11 +2141,7 @@ function showStatusUpdateSuccess(type, count, items) {
      '</div>');
 
     // Insert notifications at the top of the content area
-    if (type === 'materials') {
-        $('#materials_column_2 #notification-area').html(notification.show());
-    } else if (type === 'communications') {
-        $('#comms_column_2 #notification-area').html(notification.show());
-    }
+    $('#notification-area').html(notification.show());
 
     // Auto-hide and then REMOVE from DOM
     setTimeout(function() {


### PR DESCRIPTION
* Moved the ‘Reclassify’ success banner to the top of the page, aligning it with the others.
* Simplified notification-area handling logic by removing tab-specific conditions and centralising DOM updates.