### PR TITLE
Adds a “View in new window” button to the Review and Redact tab

### DIFF
--- a/app/assets/javascripts/housekeeping.js
+++ b/app/assets/javascripts/housekeeping.js
@@ -1388,6 +1388,9 @@ $(document).ready(function() {
           $(this).closest('tr').addClass('active_document').removeClass('unread_document');
           $(this).closest('td').prepend(`<strong class="govuk-tag active_document">Active document</strong>`);
 
+          // Enable "View in new window" button when a document becomes active
+          $('.open-Document').removeClass('govuk-button--disabled');
+
           // Scroll to a position above the tabs
           scrollToTab3Position();
      });
@@ -1628,10 +1631,46 @@ function closeRenameModal() {
 
 // Open selected documents in a new window
 function openDocumentInNewWindow() {
+    // Check if we are in the "Review and Redact" tab AND a specific document tab is visible
+    let isReviewTabVisible = $('#tab_content_3').is(':visible');
+    let activeTabPanel = $('.govuk-tabs__panel:not(.govuk-tabs__panel--hidden)');
+
+    if (isReviewTabVisible && activeTabPanel.length > 0) {
+        let pdfViewer = activeTabPanel.find('#pdf-root');
+        let documentURL = pdfViewer.attr('data-pdf-url');
+        
+        if (documentURL) {
+            // Normalize URL
+            documentURL = documentURL.replace('/public/files/', '').replace('/files/', '');
+            let windowName = 'Document_' + Date.now();
+            window.open('/public/files/' + documentURL, windowName,
+                `width=800,height=800,top=0,left=0,scrollbars=yes,location=no,toolbar=no,menubar=no,status=no`);
+            return false;
+        }
+    }
+
     // Get all selected materials and comms
     let selectedDocs = $("input[name=materials_document]:checked, input[name=comms_document]:checked");
 
-    // For each selected document
+    // If no documents are selected via checkboxes, check for the active document in the Review and Redact tab
+    if (selectedDocs.length === 0) {
+        let activeRow = $('.active_document').closest('tr');
+        if (activeRow.length > 0) {
+            let titleCell = activeRow.find('.openMe');
+            let documentURL = titleCell.find('a, button').attr('data-doc');
+            let documentTitle = titleCell.find('a, button').text().trim();
+
+            if (documentURL) {
+                // Open a new browser window for the active document
+                let windowName = 'Document_' + Date.now();
+                window.open('/public/files/' + documentURL, windowName,
+                    `width=800,height=800,top=0,left=0,scrollbars=yes,location=no,toolbar=no,menubar=no,status=no`);
+                return false;
+            }
+        }
+    }
+
+    // For each selected document (existing logic for Materials and Comms tabs)
     selectedDocs.each(function(index) {
         let row = $(this).closest('tr');
         let titleCell = row.find('td.title_column, td.subject-cell');

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -255,10 +255,10 @@
                 const document = $(`.openMe a:contains("${label}")`).attr("data-doc");
                 const count = $(`.openMe a:contains("${label}")`).attr("data-count") || 3;
                 const content = `
-                    <div class="govuk-tabs__panel govuk-tabs__panel--hidden document-panel" data-tab-id="${tabId}-content" data-is-searched="${isSearched}">  
+                    <div class="govuk-tabs__panel govuk-tabs__panel--hidden document-panel" data-tab-id="${tabId}-content" data-is-searched="${isSearched}">
 
                         <button onclick="windowSizeChange(), windowSizeChangeText()" class="window-size" id="window-size"><span>View full screen</span></button>
-                         
+
                         <!-- start of search results -->
                         <div  class="searchedDocumentSummary rj-dont-display" id="searchHeaderDisplay">
                             <div class="title">
@@ -272,25 +272,25 @@
 <!--                                    <button onclick="window.open(#)" class="">View redaction log history</button>-->
 <!--                                    <button onclick="suggestedRedactions()" class="suggested-redactions" id="suggestedRedactions">Turn <strong>ON</strong> Potential redactions</button>-->
                                     <button onclick="openRotatePagesModal(), documentTitle()" class="remove-rotate-pages-modal">Rotate document pages</button>
-                                    
+
                                     <button onclick="location.href='B-discard_material';">Discard</button>
                                     <button onclick="#">Reclassify</button>
-                                    
+
                                     <button class="govuk-button mark_as_Read" data-module="govuk-button" type="button">Mark as read</button>
                                     <button onclick="return openRenameModal(), documentRename();" class="rename-Document">Rename</button>
                                 </div>
                             </div>
 
-                            <!-- start Select Tool --> 
+                            <!-- start Select Tool -->
                             <button onclick="marqueeOn()" class="marquee" id="marquee"><span>Redact area tool</span></button>
-                            <!-- end Select Tool --> 
+                            <!-- end Select Tool -->
 
                             <div class="buttons">
                                 <p class="govuk-body-s inPageSearchMargins deactivatedPrevious">Previous</p>
                                 <p class="govuk-body-s inPageSearchMargins">1/${count}</p>
                                 <p class="govuk-body-s inPageSearchMargins looks-like-a-link-underline">Next</p>
-                            </div>  
-                        </div> 
+                            </div>
+                        </div>
                         <!-- end of search results -->
 
                         <!-- Non search heading -->
@@ -314,6 +314,11 @@
                                     <!-- Added to toggle on/off delete page -->
                                     <button onclick="#" class="">Hide delete page options</button>
 
+                                    <button type="button" class="open-Document" data-module="govuk-button" onclick="return openDocumentInNewWindow();">View in new window</button>
+
+<!--                                    <button type="button" class="govuk-button govuk-button&#45;&#45;disabled reclassify_Document_Multiple_Docs open-Document" data-module="govuk-button" onclick="return openDocumentInNewWindow();">View in new window</button>-->
+
+
                                     {% if version >= '2.0' %}
                                         <!-- Taken out for Version 1.x -->
                                         <button onclick="location.href='/version-1/B-discard_material';">Discard</button>
@@ -330,9 +335,9 @@
                                 </div>
                             </div>
 
-                            <!-- start Select Tool --> 
+                            <!-- start Select Tool -->
                             <button onclick="marqueeOn()" class="marquee" id="marquee"><span>Redact area tool</span></button>
-                            <!-- end Select Tool --> 
+                            <!-- end Select Tool -->
 
                         </div>
                         <!-- End of non search heading -->
@@ -342,12 +347,12 @@
                             <h3 class="govuk-heading-s">Potential redactions</h3>
                             <p>The following terms are items that could potentially be redacted in this document:</p>
                             <p><span id="SRNumber">(25)</span> Named individuals, <span>(2)</span> Email addresses, <span>(2)</span> Previous convictions, <span>(1)</span> Date of birth</p>
-                        </div> 
+                        </div>
 
                         <!-- <embed class="embedSize" src="/public/files/${document}#toolbar=0&view=FitH" /> -->
-                            
+
                         ${getTabHtml(`/public/files/${document}`)}
-                            
+
                     </div>`;
 
                 var $content = $(content);

--- a/public/javascripts/housekeeping.js
+++ b/public/javascripts/housekeeping.js
@@ -1388,6 +1388,9 @@ $(document).ready(function() {
           $(this).closest('tr').addClass('active_document').removeClass('unread_document');
           $(this).closest('td').prepend(`<strong class="govuk-tag active_document">Active document</strong>`);
 
+          // Enable "View in new window" button when a document becomes active
+          $('.open-Document').removeClass('govuk-button--disabled');
+
           // Scroll to a position above the tabs
           scrollToTab3Position();
      });
@@ -1628,10 +1631,46 @@ function closeRenameModal() {
 
 // Open selected documents in a new window
 function openDocumentInNewWindow() {
+    // Check if we are in the "Review and Redact" tab AND a specific document tab is visible
+    let isReviewTabVisible = $('#tab_content_3').is(':visible');
+    let activeTabPanel = $('.govuk-tabs__panel:not(.govuk-tabs__panel--hidden)');
+
+    if (isReviewTabVisible && activeTabPanel.length > 0) {
+        let pdfViewer = activeTabPanel.find('#pdf-root');
+        let documentURL = pdfViewer.attr('data-pdf-url');
+        
+        if (documentURL) {
+            // Normalize URL
+            documentURL = documentURL.replace('/public/files/', '').replace('/files/', '');
+            let windowName = 'Document_' + Date.now();
+            window.open('/public/files/' + documentURL, windowName,
+                `width=800,height=800,top=0,left=0,scrollbars=yes,location=no,toolbar=no,menubar=no,status=no`);
+            return false;
+        }
+    }
+
     // Get all selected materials and comms
     let selectedDocs = $("input[name=materials_document]:checked, input[name=comms_document]:checked");
 
-    // For each selected document
+    // If no documents are selected via checkboxes, check for the active document in the Review and Redact tab
+    if (selectedDocs.length === 0) {
+        let activeRow = $('.active_document').closest('tr');
+        if (activeRow.length > 0) {
+            let titleCell = activeRow.find('.openMe');
+            let documentURL = titleCell.find('a, button').attr('data-doc');
+            let documentTitle = titleCell.find('a, button').text().trim();
+
+            if (documentURL) {
+                // Open a new browser window for the active document
+                let windowName = 'Document_' + Date.now();
+                window.open('/public/files/' + documentURL, windowName,
+                    `width=800,height=800,top=0,left=0,scrollbars=yes,location=no,toolbar=no,menubar=no,status=no`);
+                return false;
+            }
+        }
+    }
+
+    // For each selected document (existing logic for Materials and Comms tabs)
     selectedDocs.each(function(index) {
         let row = $(this).closest('tr');
         let titleCell = row.find('td.title_column, td.subject-cell');


### PR DESCRIPTION
# Summary

Adds a “View in new window” button to the Review and Redact tab, enabling users to open the currently active document in a separate browser window.

## Key Changes
	•	Introduced a new button within Document actions:
	•	Matches existing GOV.UK button styling.
	•	Triggers openDocumentInNewWindow() on click.
	•	Implemented logic to:
	•	Identify the active document in the Review and Redact tab.
	•	Retrieve the document filename from the data-doc attribute within the openMe container.
	•	Open the selected document in a new browser window.

## Fixes & Improvements
	•	Correctly updates active document selection
	•	Ensures the button always opens the currently selected document, not the initial one.
	•	Scoped tab behaviour
	•	Prevents interference between:
	•	Review and Redact
	•	Materials
	•	Communications
	•	Each tab now maintains its own independent document selection state.

## Outcome

Users can reliably open the active document from the Review and Redact tab in a new window without affecting document selection in other tabs.