### PR TITLE
FCT2-14966 Recategorise defendant and charges

### DIFF
--- a/app/assets/javascripts/housekeeping.js
+++ b/app/assets/javascripts/housekeeping.js
@@ -1383,10 +1383,17 @@ $(document).ready(function() {
           $('.panel').hide();
           $('#tab_content_3').show();
 
-          $('#filter_Redactions table tbody tr').removeClass('active_document');
-          // $('#filter_Redactions table tbody tr td strong.govuk-tag').remove();
-          $(this).closest('tr').addClass('active_document').removeClass('unread_document');
-          $(this).closest('td').prepend(`<strong class="govuk-tag active_document">Active document</strong>`);
+          $('.active_document').removeClass('active_document');
+          $('.govuk-tag').filter(function() {
+              return $(this).text().trim() === 'Active document';
+          }).remove();
+          var $row = $(this).closest('tr');
+          var $td = $(this).closest('td');
+
+          $row.addClass('active_document').removeClass('unread_document');
+          if ($td.find('.govuk-tag').filter(function() { return $(this).text().trim() === 'Active document'; }).length === 0) {
+              $td.prepend(`<strong class="govuk-tag active_document">Active document</strong>`);
+          }
 
           // Enable "View in new window" button when a document becomes active
           $('.open-Document').removeClass('govuk-button--disabled');
@@ -1638,7 +1645,7 @@ function openDocumentInNewWindow() {
     if (isReviewTabVisible && activeTabPanel.length > 0) {
         let pdfViewer = activeTabPanel.find('#pdf-root');
         let documentURL = pdfViewer.attr('data-pdf-url');
-        
+
         if (documentURL) {
             // Normalize URL
             documentURL = documentURL.replace('/public/files/', '').replace('/files/', '');
@@ -1840,13 +1847,52 @@ function viewDefendants() {
     console.log("viewDefendants function called");
     // Open the Review & Redact Tab
     showTabByNumber(3);
-    pageActions();
 
-    // Pretty cludgy way to target the item as the numbering is duplicated currently so using first() to target the first item. Will refactor
-    $('.accordion-section.section_2').first().find('h2.govuk-heading-s > a.accordion-section-header').addClass('active');
-    $('.accordion-section.section_2').first().find('.accordion-section-body').show();
-    $('.accordion-section.section_2').first().find('#exhibits_table tbody tr:nth-child(5)').addClass("active_document");
-    $('.accordion-section.section_2').first().find('#exhibits_table tbody tr:nth-child(5) td').prepend(`<strong class="govuk-tag active_document">Active document</strong>`);
+    // Target the specific link for Asset Rec 1 (defendants.pdf)
+    var $targetLink = $('.show-case[data-id="18"][data-doc="defendants.pdf"]').first();
+
+    if ($targetLink.length > 0) {
+        // Find the parent row and section
+        var $row = $targetLink.closest('tr');
+        var $section = $targetLink.closest('.accordion-section');
+
+        // Open the accordion section if it's not already open
+        $section.find('.accordion-section-header').addClass('active');
+        $section.addClass('active');
+        $section.find('.accordion-section-body').show();
+
+        // Clear existing active documents
+        $('.active_document').removeClass("active_document");
+        $('.govuk-tag').filter(function() {
+            return $(this).text().trim() === 'Active document';
+        }).remove();
+
+        // Mark this document as active
+        $row.addClass("active_document");
+        if ($row.find('td.title_column .govuk-tag').filter(function() { return $(this).text().trim() === 'Active document'; }).length === 0) {
+            $row.find('td.title_column').prepend(`<strong class="govuk-tag active_document">Active document</strong>`);
+        }
+
+        // Trigger pageActions for the specific document
+        $targetLink.trigger('click');
+    } else {
+        // Fallback for original cludgy way if the specific document is not found
+        $('.accordion-section.section_2').first().find('h2.govuk-heading-s > a.accordion-section-header').addClass('active');
+        $('.accordion-section.section_2').first().find('.accordion-section-body').show();
+
+        // Clear existing active documents
+        $('.active_document').removeClass("active_document");
+        $('.govuk-tag').filter(function() {
+            return $(this).text().trim() === 'Active document';
+        }).remove();
+
+        var $targetTd = $('.accordion-section.section_2').first().find('#exhibits_table tbody tr:nth-child(5) td');
+        $('.accordion-section.section_2').first().find('#exhibits_table tbody tr:nth-child(5)').addClass("active_document");
+        if ($targetTd.find('.govuk-tag').filter(function() { return $(this).text().trim() === 'Active document'; }).length === 0) {
+            $targetTd.prepend(`<strong class="govuk-tag active_document">Active document</strong>`);
+        }
+        pageActions();
+    }
 }
 
 //     function updateExhibit() {

--- a/app/views/includes/version-1/redaction_filter-from-v1.2.html
+++ b/app/views/includes/version-1/redaction_filter-from-v1.2.html
@@ -16,7 +16,7 @@
 
             <!-- 1 - START Case overview (2) -->
             <div class="accordion-section section_1">
-                <h2 class="govuk-heading-s"><a class="accordion-section-header">Case overview (2)</a></h2>
+                <h2 class="govuk-heading-s"><a class="accordion-section-header">Case overview (3)</a></h2>
                 <div class="accordion-section-body">
                     <table class="govuk-table" id="other_material_table_V2">
                         <tbody class="govuk-table__body">
@@ -24,6 +24,31 @@
                         <tr class="table_header">
                             <th>Case overview</th>
                         </tr>
+
+                        <!-- ||||||||||||||| ROW 20 - START ||||||||||||||| -->
+                        {% if data['discarding_material_COMPLETED'] == 'true' and data['material_selected'] == 'Exhibit - 1' %}
+
+                        {% else %}
+                        <tr class="govuk-table__row document_row_1 material_None material_New material_All unread_document">
+                            <td class="govuk-table__cell title_column">
+                                <strong class="govuk-tag govuk-tag--blue">New</strong>
+                                <div class="openMe">
+                                    <a class="govuk-button show_material show-case" onclick="return pageActions();" data-id="18" data-doc="defendants.pdf" data-page="1">Asset Rec 1</a>
+                                </div>
+                                <p class="date-added">
+                                    Date: 03/06/2020
+                                    <button class="notes-link govuk-button has-notes" data-module="govuk-button" type="button" onClick="openNotesModal()">
+                                        <span class="notes-text">Notes:</span> <span class="new-notes-number"></span>
+                                        <span class="visuallyhidden notes-text-content">
+                                                    <strong>Notes:</strong>
+                                                    <span class="notes-content">Redacted, reviewed, do not serve</span>
+                                                </span>
+                                    </button>
+                                </p>
+                            </td>
+                        </tr>
+                        {% endif %}
+                        <!-- ||||||||||||||| ROW 20 - END ||||||||||||||| -->
 
                         <!-- ||||||||||||||| ROW 2 - START ||||||||||||||| -->
                         {% if data['discarding_material_COMPLETED'] == 'true' and data['material_selected'] == 'Case overview and officer comments' %}

--- a/app/views/includes/version-1/redaction_filter.html
+++ b/app/views/includes/version-1/redaction_filter.html
@@ -205,6 +205,30 @@
                                                 <tr class="table_header">
                                                     <th>Case overview</th>
                                                 </tr>
+                                                <!-- ||||||||||||||| ROW 20 - START ||||||||||||||| -->
+                                                {% if data['discarding_material_COMPLETED'] == 'true' and data['material_selected'] == 'Exhibit - 1' %}
+
+                                                {% else %}
+                                                <tr class="govuk-table__row document_row_1 material_None material_New material_All unread_document">
+                                                    <td class="govuk-table__cell title_column">
+                                                        <strong class="govuk-tag govuk-tag--blue">New</strong>
+                                                        <div class="openMe">
+                                                            <a class="govuk-button show_material show-case" onclick="return pageActions();" data-id="18" data-doc="defendants.pdf" data-page="1">Asset Rec 1</a>
+                                                        </div>
+                                                        <p class="date-added">
+                                                            Date: 03/06/2020
+                                                            <button class="notes-link govuk-button has-notes" data-module="govuk-button" type="button" onClick="openNotesModal()">
+                                                                <span class="notes-text">Notes:</span> <span class="new-notes-number"></span>
+                                                                <span class="visuallyhidden notes-text-content">
+                                                    <strong>Notes:</strong>
+                                                    <span class="notes-content">Redacted, reviewed, do not serve</span>
+                                                </span>
+                                                            </button>
+                                                        </p>
+                                                    </td>
+                                                </tr>
+                                                {% endif %}
+                                                <!-- ||||||||||||||| ROW 20 - END ||||||||||||||| -->
 
                                                 <!-- ||||||||||||||| ROW 2 - START ||||||||||||||| -->
                                                 {% if data['discarding_material_COMPLETED'] == 'true' and data['material_selected'] == 'Case overview and officer comments' %}
@@ -724,31 +748,6 @@
 <!--                            </tr>-->
                         {% endif %}
                         <!-- ||||||||||||||| ROW 16 - END ||||||||||||||| -->
-
-                        <!-- ||||||||||||||| ROW 20 - START ||||||||||||||| -->
-                        {% if data['discarding_material_COMPLETED'] == 'true' and data['material_selected'] == 'Exhibit - 1' %}
-
-                        {% else %}
-                        <tr class="govuk-table__row document_row_18 material_Exhibit material_None material_New material_All unread_document">
-                            <td class="govuk-table__cell title_column">
-                                <strong class="govuk-tag govuk-tag--blue">New</strong>
-                                <div class="openMe">
-                                    <a class="govuk-button show_material show-case" onclick="return pageActions();" data-id="18" data-doc="defendants.pdf" data-page="1">Asset Rec 1</a>
-                                </div>
-                                <p class="date-added">
-                                    Date: 03/06/2020
-                                    <button class="notes-link govuk-button has-notes" data-module="govuk-button" type="button" onClick="openNotesModal()">
-                                        <span class="notes-text">Notes:</span> <span class="new-notes-number"></span>
-                                        <span class="visuallyhidden notes-text-content">
-                                                    <strong>Notes:</strong>
-                                                    <span class="notes-content">Redacted, reviewed, do not serve</span>
-                                                </span>
-                                    </button>
-                                </p>
-                            </td>
-                        </tr>
-                        {% endif %}
-                        <!-- ||||||||||||||| ROW 20 - END ||||||||||||||| -->
 
                         <!-- ||||||||||||||| ROW 18 - START ||||||||||||||| -->
                         {% if data['discarding_material_COMPLETED'] == 'true' and data['material_selected'] == 'Asset Rec 1' %}

--- a/public/javascripts/housekeeping.js
+++ b/public/javascripts/housekeeping.js
@@ -1383,10 +1383,17 @@ $(document).ready(function() {
           $('.panel').hide();
           $('#tab_content_3').show();
 
-          $('#filter_Redactions table tbody tr').removeClass('active_document');
-          // $('#filter_Redactions table tbody tr td strong.govuk-tag').remove();
-          $(this).closest('tr').addClass('active_document').removeClass('unread_document');
-          $(this).closest('td').prepend(`<strong class="govuk-tag active_document">Active document</strong>`);
+          $('.active_document').removeClass('active_document');
+          $('.govuk-tag').filter(function() {
+              return $(this).text().trim() === 'Active document';
+          }).remove();
+          var $row = $(this).closest('tr');
+          var $td = $(this).closest('td');
+          
+          $row.addClass('active_document').removeClass('unread_document');
+          if ($td.find('.govuk-tag').filter(function() { return $(this).text().trim() === 'Active document'; }).length === 0) {
+              $td.prepend(`<strong class="govuk-tag active_document">Active document</strong>`);
+          }
 
           // Enable "View in new window" button when a document becomes active
           $('.open-Document').removeClass('govuk-button--disabled');
@@ -1638,7 +1645,7 @@ function openDocumentInNewWindow() {
     if (isReviewTabVisible && activeTabPanel.length > 0) {
         let pdfViewer = activeTabPanel.find('#pdf-root');
         let documentURL = pdfViewer.attr('data-pdf-url');
-        
+
         if (documentURL) {
             // Normalize URL
             documentURL = documentURL.replace('/public/files/', '').replace('/files/', '');
@@ -1840,13 +1847,52 @@ function viewDefendants() {
     console.log("viewDefendants function called");
     // Open the Review & Redact Tab
     showTabByNumber(3);
-    pageActions();
 
-    // Pretty cludgy way to target the item as the numbering is duplicated currently so using first() to target the first item. Will refactor
-    $('.accordion-section.section_2').first().find('h2.govuk-heading-s > a.accordion-section-header').addClass('active');
-    $('.accordion-section.section_2').first().find('.accordion-section-body').show();
-    $('.accordion-section.section_2').first().find('#exhibits_table tbody tr:nth-child(5)').addClass("active_document");
-    $('.accordion-section.section_2').first().find('#exhibits_table tbody tr:nth-child(5) td').prepend(`<strong class="govuk-tag active_document">Active document</strong>`);
+    // Target the specific link for Asset Rec 1 (defendants.pdf)
+    var $targetLink = $('.show-case[data-id="18"][data-doc="defendants.pdf"]').first();
+
+    if ($targetLink.length > 0) {
+        // Find the parent row and section
+        var $row = $targetLink.closest('tr');
+        var $section = $targetLink.closest('.accordion-section');
+
+        // Open the accordion section if it's not already open
+        $section.find('.accordion-section-header').addClass('active');
+        $section.addClass('active');
+        $section.find('.accordion-section-body').show();
+
+        // Clear existing active documents
+        $('.active_document').removeClass("active_document");
+        $('.govuk-tag').filter(function() {
+            return $(this).text().trim() === 'Active document';
+        }).remove();
+
+        // Mark this document as active
+        $row.addClass("active_document");
+        if ($row.find('td.title_column .govuk-tag').filter(function() { return $(this).text().trim() === 'Active document'; }).length === 0) {
+            $row.find('td.title_column').prepend(`<strong class="govuk-tag active_document">Active document</strong>`);
+        }
+
+        // Trigger pageActions for the specific document
+        $targetLink.trigger('click');
+    } else {
+        // Fallback for original cludgy way if the specific document is not found
+        $('.accordion-section.section_2').first().find('h2.govuk-heading-s > a.accordion-section-header').addClass('active');
+        $('.accordion-section.section_2').first().find('.accordion-section-body').show();
+
+        // Clear existing active documents
+        $('.active_document').removeClass("active_document");
+        $('.govuk-tag').filter(function() {
+            return $(this).text().trim() === 'Active document';
+        }).remove();
+
+        var $targetTd = $('.accordion-section.section_2').first().find('#exhibits_table tbody tr:nth-child(5) td');
+        $('.accordion-section.section_2').first().find('#exhibits_table tbody tr:nth-child(5)').addClass("active_document");
+        if ($targetTd.find('.govuk-tag').filter(function() { return $(this).text().trim() === 'Active document'; }).length === 0) {
+            $targetTd.prepend(`<strong class="govuk-tag active_document">Active document</strong>`);
+        }
+        pageActions();
+    }
 }
 
 //     function updateExhibit() {


### PR DESCRIPTION
This pull request improves how the "Active document" state is managed in the UI, especially when interacting with the "Asset Rec 1" document, and refines the logic for displaying this document in the case overview and exhibits tables. The JavaScript logic is now more robust and prevents duplicate "Active document" tags, and the HTML templates have been updated to ensure "Asset Rec 1" only appears in the correct context.

**JavaScript improvements to active document handling:**

* Refactored the logic for marking a document as active to ensure only one "Active document" tag is present at a time, and to prevent duplicate tags from being added. This includes updating both `housekeeping.js` and `public/javascripts/housekeeping.js`. [[1]](diffhunk://#diff-5c3c29c9c79354fc9e01435086e1b96ac1b1087eeeaa2099b0de560dbc9b46e5L1386-R1396) [[2]](diffhunk://#diff-6d19e2252a54d9a575d9a335da129a2f0d7feb08b23cf22f8f2b9848b9bb708aL1386-R1396)
* Improved the `viewDefendants` function to reliably target and activate the "Asset Rec 1" document by its unique data attributes, open its containing accordion section, and update the active state and tag. If the document is not found, it falls back to the previous logic. [[1]](diffhunk://#diff-5c3c29c9c79354fc9e01435086e1b96ac1b1087eeeaa2099b0de560dbc9b46e5L1843-R1895) [[2]](diffhunk://#diff-6d19e2252a54d9a575d9a335da129a2f0d7feb08b23cf22f8f2b9848b9bb708aL1843-R1895)

**HTML template updates for "Asset Rec 1" display:**

* Moved the "Asset Rec 1" row from the Exhibits table to the Case Overview table in both `redaction_filter.html` and `redaction_filter-from-v1.2.html`, ensuring it only appears in one location at a time. The row is now conditionally rendered based on form data. [[1]](diffhunk://#diff-121845ad3b0d3768782f430e687eb9f173c1a2d408044ef5c897365157416642R208-R231) [[2]](diffhunk://#diff-0a0fc5d33e252b256f7fb858b171eb697cc9278e7402a38a20c287061115ace9R28-R52)
* Updated the Case Overview section heading to reflect the new document count after moving "Asset Rec 1".
* Removed the now-redundant "Asset Rec 1" row from the Exhibits table in `redaction_filter.html`.