### PR TITLE
Updated redaction filter labels in version-1 to improve clarity

### DIFF
--- a/app/views/includes/version-1/redaction_filter-from-v1.2.html
+++ b/app/views/includes/version-1/redaction_filter-from-v1.2.html
@@ -7,7 +7,7 @@
         <div class="moj-filter__options redaction_options">
 
             <div class="govuk-form-group search_container">
-                <label class="govuk-label govuk-label--s" for="filter_materials__Search">Search materials</label>
+                <label class="govuk-label govuk-label--s" for="filter_materials__Search">Search within materials</label>
                 <div>
                     <input class="govuk-input" id="searchURNModal" name="searchURNModal" type="text">
                     <button id="search_materials" type="button" class="govuk-button" data-module="govuk-button" onclick="openModal(); searchTerm();">Search</button>

--- a/app/views/includes/version-1/redaction_filter.html
+++ b/app/views/includes/version-1/redaction_filter.html
@@ -8,7 +8,7 @@
         <div class="moj-filter__options redaction_options">
 
             <div class="govuk-form-group search_container">
-                <label class="govuk-label govuk-label--s" for="filter_materials__Search">Search materials</label>
+                <label class="govuk-label govuk-label--s" for="filter_materials__Search">Search within materials</label>
                 <div>
                     <input class="govuk-input" id="searchURNModal" name="searchURNModal" type="text">
                     <button id="search_materials" type="button" class="govuk-button" data-module="govuk-button" onclick="openModal(); searchTerm();">Search</button>


### PR DESCRIPTION
The search in the Materials and Communications tab searches titles, whereas the search on the Review and Redact tab searches the title and the document contents.

The PO requested the label change for clarification.